### PR TITLE
Refactor tests to generate test image dynamically

### DIFF
--- a/bitmap2svg/tests/assets/README.md
+++ b/bitmap2svg/tests/assets/README.md
@@ -1,0 +1,3 @@
+The sample test image has been removed from this repository.
+
+Tests dynamically generate any required images. If you need to run experiments with specific input files, place them outside version control and reference them via custom fixtures or temporary files.

--- a/bitmap2svg/tests/test_smoke.py
+++ b/bitmap2svg/tests/test_smoke.py
@@ -2,31 +2,40 @@ from bitmap2svg.ingest import load
 from bitmap2svg.pipeline import vectorise
 from bitmap2svg.config import Settings
 import pytest
-import os
+import base64
+
 
 @pytest.fixture
-def sample_image():
-    # Provide a path to a sample image for testing
-    return "tests/assets/sample_logo.png"
+def sample_image(tmp_path):
+    png_base64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgMBg8UoAA=="
+    )
+    img_path = tmp_path / "sample.png"
+    img_path.write_bytes(base64.b64decode(png_base64))
+    return img_path
+
 
 def test_vectorise(sample_image):
     cfg = Settings()
     img = load(sample_image)
     result = vectorise(img, cfg)
-    
+
     assert result.svg_min is not None
     assert isinstance(result.svg_min, str)
     assert len(result.svg_min) > 0
+
 
 def test_metrics(sample_image):
     cfg = Settings()
     img = load(sample_image)
     result = vectorise(img, cfg)
-    
+
     assert "ssim" in result.metrics
     assert "edge_iou" in result.metrics
     assert "bytes" in result.metrics
 
-def test_invalid_image():
+
+def test_invalid_image(tmp_path):
     with pytest.raises(FileNotFoundError):
-        load("tests/assets/non_existent_image.png")
+        load(tmp_path / "non_existent_image.png")
+


### PR DESCRIPTION
## Summary
- Use a dynamically generated temporary PNG in smoke tests instead of relying on `tests/assets/sample_logo.png`
- Add README explaining how to supply or generate test images locally

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c1a16f41cc83208947a0b579befcf6