### PR TITLE
Implement caching and batching in vectorisation pipeline

### DIFF
--- a/bitmap2svg/bitmap2svg/pipeline.py
+++ b/bitmap2svg/bitmap2svg/pipeline.py
@@ -1,20 +1,31 @@
+"""Core vectorisation pipeline with caching and batching utilities."""
+
 from __future__ import annotations
-from typing import Iterable
-from .config import Settings
-from .ingest import LoadedImage
-from .segment import to_layers, mask_to_bw
-from .simplify import rdp_all
-from .vector_critic import snap, SnapCfg
-from .bezier import fit as bezier_fit
-from .svg_io import compose
-from .qa import evaluate
+
+from functools import lru_cache
+from typing import Iterable, List, Tuple
+
+import numpy as np
 import potrace
 
-def _potrace_trace(bw_u8):
+from .bezier import fit as bezier_fit
+from .config import Settings
+from .ingest import LoadedImage
+from .qa import evaluate
+from .segment import mask_to_bw, to_layers
+from .simplify import rdp_all
+from .svg_io import compose
+from .vector_critic import snap, SnapCfg
+
+
+@lru_cache(maxsize=128)
+def _potrace_trace_cached(bw_bytes: bytes, width: int, height: int) -> List[List[Tuple[float, float]]]:
+    """Trace binary image data with Potrace and cache the result."""
+    bw_u8 = np.frombuffer(bw_bytes, dtype=np.uint8).reshape((height, width))
     bmp = potrace.Bitmap(bw_u8 > 0)
-    seeds = []
+    seeds: List[List[Tuple[float, float]]] = []
     for curve in bmp.trace().curves:
-        pts = []
+        pts: List[Tuple[float, float]] = []
         for seg in curve.segments:
             pts.append((float(seg.c.x), float(seg.c.y)))
         if len(pts) >= 3 and pts[0] != pts[-1]:
@@ -23,7 +34,15 @@ def _potrace_trace(bw_u8):
             seeds.append(pts)
     return seeds
 
+
+def _potrace_trace(bw_u8: np.ndarray) -> List[List[Tuple[float, float]]]:
+    """Wrapper around the cached Potrace call using array data."""
+    h, w = bw_u8.shape
+    return _potrace_trace_cached(bw_u8.tobytes(), w, h)
+
+
 def vectorise(img: LoadedImage, cfg: Settings):
+    """Vectorise a single loaded image into an SVG result."""
     layers = to_layers(img, cfg)
     composed = []
     for layer in layers:
@@ -31,12 +50,17 @@ def vectorise(img: LoadedImage, cfg: Settings):
         seeds = _potrace_trace(bw)
         polys = rdp_all(seeds, epsilon=cfg.rdp_epsilon)
         snapped = snap(polys, cfg.snap)
-        beziers = bezier_fit([p for t, p in snapped if t == "poly"], cfg.bezier)
         items = [(t, p) for (t, p) in snapped if t in ("circle", "rect")]
         poly_left = [p for (t, p) in snapped if t == "poly"]
-        bez = fit(poly_left, cfg.bezier)
+        bez = bezier_fit(poly_left, cfg.bezier)
         items.extend(bez)
         composed.append((items, layer.color))
     svg = compose(composed, img.size, cfg.svg).minified
     metrics = evaluate(svg, img, cfg.qa)
     return type("SVGResult", (), {"svg_min": svg, "svg_pretty": svg, "metrics": metrics})
+
+
+def vectorise_batch(images: Iterable[LoadedImage], cfg: Settings):
+    """Vectorise a batch of images, leveraging cached Potrace traces."""
+    return [vectorise(img, cfg) for img in images]
+

--- a/bitmap2svg/bitmap2svg/service.py
+++ b/bitmap2svg/bitmap2svg/service.py
@@ -1,33 +1,65 @@
-from fastapi import FastAPI, UploadFile, File
-from starlette.responses import JSONResponse
-from bitmap2svg.pipeline import vectorise
-from bitmap2svg.ingest import load
-from bitmap2svg.config import Settings
-import json
+"""FastAPI service exposing vectorisation endpoints with caching and batching."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from io import BytesIO
 from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI, File, UploadFile
+from starlette.responses import JSONResponse
+
+from bitmap2svg.config import Settings
+from bitmap2svg.ingest import load
+from bitmap2svg.pipeline import vectorise
+
 
 app = FastAPI()
 
+
+@lru_cache(maxsize=32)
+def _vectorise_cached(data: bytes, cfg_json: str):
+    """Cache the vectorisation of raw image bytes with a given config."""
+    cfg = Settings.model_validate_json(cfg_json)
+    img = load(BytesIO(data))
+    return vectorise(img, cfg)
+
+
 @app.post("/vectorise")
-async def vectorise_image(file: UploadFile = File(...), cfg_path: str = None):
+async def vectorise_image(file: UploadFile = File(...), cfg_path: str | None = None):
     try:
-        # Load configuration settings
-        cfg = Settings.model_validate_json(Path(cfg_path).read_text()) if cfg_path else Settings()
-        
-        # Load the image
-        img = load(file.file)
-        
-        # Vectorise the image
-        res = vectorise(img, cfg)
-        
-        # Return the SVG result and metrics
-        return JSONResponse(content={
-            "svg": res.svg_min,
-            "metrics": res.metrics
-        })
+        cfg = (
+            Settings.model_validate_json(Path(cfg_path).read_text())
+            if cfg_path
+            else Settings()
+        )
+        data = await file.read()
+        res = _vectorise_cached(data, cfg.model_dump_json())
+        return JSONResponse(content={"svg": res.svg_min, "metrics": res.metrics})
     except Exception as e:
         return JSONResponse(content={"error": str(e)}, status_code=400)
+
+
+@app.post("/vectorise-batch")
+async def vectorise_batch(files: List[UploadFile], cfg_path: str | None = None):
+    try:
+        cfg = (
+            Settings.model_validate_json(Path(cfg_path).read_text())
+            if cfg_path
+            else Settings()
+        )
+        results = []
+        for f in files:
+            data = await f.read()
+            res = _vectorise_cached(data, cfg.model_dump_json())
+            results.append({"svg": res.svg_min, "metrics": res.metrics})
+        return JSONResponse(content={"results": results})
+    except Exception as e:
+        return JSONResponse(content={"error": str(e)}, status_code=400)
+
 
 @app.get("/status")
 def status():
     return {"status": "Service is running"}
+

--- a/bitmap2svg/tests/test_pipeline_perf.py
+++ b/bitmap2svg/tests/test_pipeline_perf.py
@@ -1,0 +1,43 @@
+"""Tests for caching and batching behaviour in pipeline."""
+
+import base64
+
+import pytest
+
+from bitmap2svg.ingest import load
+from bitmap2svg.config import Settings
+from bitmap2svg.pipeline import (
+    vectorise,
+    vectorise_batch,
+    _potrace_trace_cached,
+)
+
+
+@pytest.fixture
+def sample_image(tmp_path):
+    png_base64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgMBg8UoAA=="
+    )
+    img_path = tmp_path / "sample.png"
+    img_path.write_bytes(base64.b64decode(png_base64))
+    return load(img_path)
+
+
+def test_caching(sample_image):
+    cfg = Settings()
+    _potrace_trace_cached.cache_clear()
+    vectorise(sample_image, cfg)
+    first_hits = _potrace_trace_cached.cache_info().hits
+    vectorise(sample_image, cfg)
+    second_hits = _potrace_trace_cached.cache_info().hits
+    assert second_hits > first_hits
+
+
+def test_vectorise_batch(sample_image):
+    cfg = Settings()
+    _potrace_trace_cached.cache_clear()
+    images = [sample_image, sample_image]
+    results = vectorise_batch(images, cfg)
+    assert len(results) == 2
+    assert _potrace_trace_cached.cache_info().hits > 0
+


### PR DESCRIPTION
## Summary
- add cached Potrace tracing and batch helper to the vectorisation pipeline
- expose cached single and batch endpoints in the FastAPI service
- include tests demonstrating cache hits and batch processing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bitmap2svg')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c46e540083209b643cd2d8a3b669