### PR TITLE
feat: parallel batch processing with CLI

### DIFF
--- a/bitmap2svg/README.md
+++ b/bitmap2svg/README.md
@@ -45,6 +45,14 @@ To process a batch of images, use:
 python -m bitmap2svg.cli batch path/to/images/ -o output_directory/
 ```
 
+The batch command also supports parallel processing. Use ``--jobs`` to set the
+number of worker threads. For example, to process images using four threads and
+silence the progress display:
+
+```bash
+python -m bitmap2svg.cli batch path/to/images/ out --jobs 4 --quiet
+```
+
 ### FastAPI Service
 
 To run the FastAPI service, execute:

--- a/bitmap2svg/bitmap2svg/cli.py
+++ b/bitmap2svg/bitmap2svg/cli.py
@@ -1,35 +1,102 @@
 from __future__ import annotations
+
+"""Command line interface for bitmap2svg.
+
+This module exposes two commands:
+
+``vectorise``
+    Convert a single image to SVG.
+
+``batch``
+    Convert all images under a directory to SVG, optionally using multiple
+    threads for faster processing. Progress can be disabled with ``--quiet``.
+"""
+
 import json
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Iterable
+
 import typer
+from rich.progress import track
+
 from .config import Settings
 from .ingest import load
 from .pipeline import vectorise
 
 app = typer.Typer(add_completion=False)
 
+
 @app.command("vectorise")
-def vectorise_cmd(input: str, out: str = "out.svg", cfg: str | None = None):
+def vectorise_cmd(input: str, out: str = "out.svg", cfg: str | None = None) -> None:
+    """Vectorise a single image ``input`` and write the SVG to ``out``."""
     settings = Settings.model_validate_json(Path(cfg).read_text()) if cfg else Settings()
     img = load(input)
     res = vectorise(img, settings)
     Path(out).write_text(res.svg_min, encoding="utf-8")
     typer.echo(json.dumps(res.metrics, indent=2))
 
-@app.command("batch")
-def batch_cmd(src: str, dst: str = "out", cfg: str | None = None):
-    settings = Settings.model_validate_json(Path(cfg).read_text()) if cfg else Settings()
-    Path(dst).mkdir(parents=True, exist_ok=True)
-    for p in Path(src).glob("**/*.*"):
-        if p.suffix.lower() not in {".png",".jpg",".jpeg",".webp"}:
-            continue
-        try:
-            img = load(p)
-            res = vectorise(img, settings)
-            Path(dst, p.with_suffix(".svg").name).write_text(res.svg_min, encoding="utf-8")
-            typer.echo(f"OK {p.name}  {res.metrics}")
-        except Exception as e:
-            typer.secho(f"FAIL {p}: {e}", fg="red")
 
-if __name__ == "__main__":
+def _iter_images(src: Path) -> list[Path]:
+    """Return all image files under ``src`` that we know how to handle."""
+    return [
+        p
+        for p in src.glob("**/*.*")
+        if p.suffix.lower() in {".png", ".jpg", ".jpeg", ".webp"}
+    ]
+
+
+def _process(p: Path, dst: Path, settings: Settings):
+    """Process ``p`` returning a tuple of (ok, path, metrics_or_error)."""
+    try:
+        img = load(p)
+        res = vectorise(img, settings)
+        Path(dst, p.with_suffix(".svg").name).write_text(res.svg_min, encoding="utf-8")
+        return True, p, res.metrics
+    except Exception as e:  # pragma: no cover - exception path
+        return False, p, e
+
+
+@app.command("batch")
+def batch_cmd(
+    src: str,
+    dst: str = "out",
+    cfg: str | None = None,
+    jobs: int = 1,
+    quiet: bool = False,
+) -> None:
+    """Vectorise all images in ``src`` placing results in ``dst``.
+
+    ``jobs`` controls the number of worker threads. When set to 1 the images are
+    processed sequentially. Set ``quiet`` to ``True`` to disable the progress
+    display which is useful for automated testing.
+    """
+
+    settings = Settings.model_validate_json(Path(cfg).read_text()) if cfg else Settings()
+    src_p = Path(src)
+    dst_p = Path(dst)
+    dst_p.mkdir(parents=True, exist_ok=True)
+    paths = _iter_images(src_p)
+
+    def iterator() -> Iterable:
+        if jobs > 1:
+            with ThreadPoolExecutor(max_workers=jobs) as ex:
+                yield from ex.map(lambda p: _process(p, dst_p, settings), paths)
+        else:
+            for p in paths:
+                yield _process(p, dst_p, settings)
+
+    it = iterator()
+    if not quiet:
+        it = track(it, total=len(paths), description="Vectorising")
+
+    for ok, p, data in it:
+        if ok:
+            typer.echo(f"OK {p.name}  {data}")
+        else:
+            typer.secho(f"FAIL {p}: {data}", fg="red")
+
+
+if __name__ == "__main__":  # pragma: no cover
     app()
+

--- a/bitmap2svg/tests/test_cli_batch.py
+++ b/bitmap2svg/tests/test_cli_batch.py
@@ -1,0 +1,29 @@
+import base64
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from bitmap2svg.cli import app
+
+
+PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgMBg8UoAA=="
+
+
+def _write_sample(path: Path) -> None:
+    path.write_bytes(base64.b64decode(PNG_B64))
+
+
+def test_batch_parallel(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    _write_sample(src / "a.png")
+    _write_sample(src / "b.png")
+
+    out = tmp_path / "out"
+    runner = CliRunner()
+    result = runner.invoke(app, ["batch", str(src), str(out), "--jobs", "2", "--quiet"])
+
+    assert result.exit_code == 0
+    assert (out / "a.svg").exists()
+    assert (out / "b.svg").exists()
+


### PR DESCRIPTION
## Summary
- add ThreadPoolExecutor-powered `--jobs` option to CLI batch command with optional progress display
- document parallel batch usage in README
- test batch command parallelism using Typer's CliRunner

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c8cce7508320b3387e1ef589f224